### PR TITLE
Implement the CDC iterator

### DIFF
--- a/source/iterator/cdc.go
+++ b/source/iterator/cdc.go
@@ -1,0 +1,194 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// metadataFieldCollection is a name of a record metadata field that stores a MongoDB collection name.
+const metadataFieldCollection = "mongo.collection"
+
+// The supported Change Stream event operation types are listed below.
+const (
+	OperationTypeInsert = "insert"
+	OperationTypeUpdate = "update"
+	OperationTypeDelete = "delete"
+)
+
+// changeStreamMatchPipeline is a MongoDB Change Stream pipeline that
+// filters and returns only insert, update and delete events.
+var changeStreamMatchPipeline = bson.D{
+	{
+		Key: "$match", Value: bson.M{
+			"operationType": bson.M{"$in": []string{
+				OperationTypeInsert,
+				OperationTypeUpdate,
+				OperationTypeDelete,
+			}},
+		},
+	},
+}
+
+// changeStreamEvent defines a Change Stream event type.
+// It consists of all fields sufficient to process inserts, updates, and deletes.
+type changeStreamEvent struct {
+	// ID is a BSON object which serves as an identifier for the Change Stream event.
+	// This value is used as the resumeToken.
+	ID bson.Raw `bson:"_id"`
+	// DocumentKey contains the _id field of a document.
+	DocumentKey map[string]any `bson:"documentKey"`
+	// OperationType is the type of an operation that the Change Stream reports.
+	OperationType string `bson:"operationType"`
+	// WallTime is the server date and time of the database operation.
+	WallTime time.Time `bson:"wallTime"`
+	// FullDocument contains all fields of a document.
+	FullDocument map[string]any `bson:"fullDocument"`
+	// Namespace is a namespace affected by the event.
+	Namespace struct {
+		// Collection is the name of a collection where the event occurred.
+		Collection string `bson:"coll"`
+	} `bson:"ns"`
+}
+
+// toRecord converts the underlying [changeStreamEvent] to an [sdk.Record].
+func (e changeStreamEvent) toRecord() (sdk.Record, error) {
+	position := &Position{e.ID}
+
+	sdkPosition, err := position.MarshalSDKPosition()
+	if err != nil {
+		return sdk.Record{}, fmt.Errorf("marshal position into sdk.Position: %w", err)
+	}
+
+	// set the record metadata
+	metadata := make(sdk.Metadata)
+	metadata[metadataFieldCollection] = e.Namespace.Collection
+	metadata.SetCreatedAt(e.WallTime)
+
+	switch e.OperationType {
+	case OperationTypeInsert:
+		return sdk.Util.Source.NewRecordCreate(
+			sdkPosition, metadata, sdk.StructuredData(e.DocumentKey), sdk.StructuredData(e.FullDocument),
+		), nil
+
+	case OperationTypeUpdate:
+		return sdk.Util.Source.NewRecordUpdate(
+			sdkPosition, metadata, sdk.StructuredData(e.DocumentKey), nil, sdk.StructuredData(e.FullDocument),
+		), nil
+
+	case OperationTypeDelete:
+		return sdk.Util.Source.NewRecordDelete(
+			sdkPosition, metadata, sdk.StructuredData(e.DocumentKey),
+		), nil
+
+	default:
+		// this shouldn't happen as we filter Change Stream events by operation type,
+		// and get only insert, update, and delete
+		return sdk.Record{}, ErrUnsupportedOperationType
+	}
+}
+
+// CDC implements a Change Data Capture iterator for the MongoDB.
+// It works by creating and listening to a MongoDB [Change Stream].
+//
+// [Change Stream]: https://www.mongodb.com/docs/manual/changeStreams/.
+type CDC struct {
+	changeStream *mongo.ChangeStream
+}
+
+// NewCDC creates a new instance of the [CDC].
+func NewCDC(ctx context.Context, collection *mongo.Collection, sdkPosition sdk.Position) (*CDC, error) {
+	position, err := ParsePosition(sdkPosition)
+	if err != nil && !errors.Is(err, ErrNilSDKPosition) {
+		return nil, fmt.Errorf("parse sdk.Position: %w", err)
+	}
+
+	changeStream, err := createChangeStream(ctx, collection, position)
+	if err != nil {
+		return nil, fmt.Errorf("create change stream: %w", err)
+	}
+
+	return &CDC{
+		changeStream: changeStream,
+	}, nil
+}
+
+// HasNext checks whether the [CDC] iterator has records to return or not.
+func (c *CDC) HasNext(ctx context.Context) (bool, error) {
+	return c.changeStream.TryNext(ctx), c.changeStream.Err()
+}
+
+// Next returns the next record.
+func (c *CDC) Next(ctx context.Context) (sdk.Record, error) {
+	var event changeStreamEvent
+	if err := c.changeStream.Decode(&event); err != nil {
+		return sdk.Record{}, fmt.Errorf("decode change stream event: %w", err)
+	}
+
+	record, err := event.toRecord()
+	if err != nil {
+		return sdk.Record{}, fmt.Errorf("convert event to sdk.Record: %w", err)
+	}
+
+	return record, nil
+}
+
+// Stop stops the iterator.
+func (c *CDC) Stop(ctx context.Context) error {
+	if c.changeStream != nil {
+		if err := c.changeStream.Close(ctx); err != nil {
+			return fmt.Errorf("close change stream: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// createChangeStream creates a MongoDB Change Stream for a provided collection.
+// The resulting Change Stream will listen to events only with the following
+// operation types: insert, update and delete.
+//
+// If a provided [Position] is not empty and it has a resumeToken, the Change Stream
+// will start listening to events from that particular position.
+func createChangeStream(
+	ctx context.Context,
+	collection *mongo.Collection,
+	position *Position,
+) (*mongo.ChangeStream, error) {
+	// the UpdateLookup option includes a delta describing the changes to the document
+	// and a copy of the entire document that was changed
+	opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
+
+	// if a position is not nil and its resumeToken is not empty,
+	// we'll start listening to the Change Stream from that particular position
+	if position != nil && position.ResumeToken != nil {
+		opts = opts.SetResumeAfter(position.ResumeToken)
+	}
+
+	changeStream, err := collection.Watch(ctx, mongo.Pipeline{changeStreamMatchPipeline}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("create change stream on the %q collection: %w", collection.Name(), err)
+	}
+
+	return changeStream, nil
+}

--- a/source/iterator/errors.go
+++ b/source/iterator/errors.go
@@ -1,0 +1,28 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import "errors"
+
+var (
+	// ErrUnsupportedOperationType occurs when we got an unsupported operation type.
+	// This error shouldn't actually occur, as we filter Change Stream events by operation type.
+	// It's just a sentinel error for the [changeStreamEvent.toRecord] method.
+	ErrUnsupportedOperationType = errors.New("unsupported operation type")
+
+	// ErrNilSDKPosition occurs when trying to parse a nil [sdk.Position].
+	// It's just a sentinel error for the [ParsePosition] function.
+	ErrNilSDKPosition = errors.New("nil sdk position")
+)

--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -1,0 +1,54 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// Position is an iterator position.
+// It consists of a resumeToken token that allows us to resume a Change Stream
+// or restart a snapshot process from a particular position.
+type Position struct {
+	ResumeToken bson.Raw `json:"resumeToken"`
+}
+
+// MarshalSDKPosition marshals the underlying [Position] into a [sdk.Position] as JSON bytes.
+func (p *Position) MarshalSDKPosition() (sdk.Position, error) {
+	positionBytes, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal position: %w", err)
+	}
+
+	return sdk.Position(positionBytes), nil
+}
+
+// ParsePosition converts an [sdk.Position] into a [Position].
+func ParsePosition(sdkPosition sdk.Position) (*Position, error) {
+	if sdkPosition == nil {
+		return nil, ErrNilSDKPosition
+	}
+
+	var position Position
+	if err := json.Unmarshal(sdkPosition, &position); err != nil {
+		return nil, fmt.Errorf("unmarshal sdk.Position into Position: %w", err)
+	}
+
+	return &position, nil
+}


### PR DESCRIPTION
### Description

This PR seeks to implement the CDC iterator.

It works by creating and listening to a MongoDB [Change Stream](https://www.mongodb.com/docs/manual/changeStreams/). The Change Stream can be resumed by a `resumeToken` that every Change Stream event has in its payload. The CDC iterator stores the `resumeToken` in the `Position`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
