### PR TITLE
Update the `Config.URI` field

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
           go-version: 1.18
 
       - name: Test
-        run: make test GOTEST_FLAGS="-v -count=1 -race"
+        run: make test MONGODB_STARTUP_TIMEOUT=8 GOTEST_FLAGS="-v -count=1 -race"

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ build:
 	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-mongo.version=${VERSION}'" -o conduit-connector-mongo cmd/connector/main.go
 
 test:
-	docker run --rm -d -p 27017:27017 --name mongodb mongo --replSet=test && \
-	sleep $(MONGODB_STARTUP_TIMEOUT) && \
+	docker run --rm -d -p 27017:27017 --name mongodb mongo --replSet=test
+	sleep $(MONGODB_STARTUP_TIMEOUT) 
 	docker exec mongodb mongosh --eval "rs.initiate();"
-	go test $(GOTEST_FLAGS) ./... && \
-	docker stop mongodb
+	go test $(GOTEST_FLAGS) ./...; ret=$$?; \
+		docker stop mongodb; \
+		exit $$ret
 
 lint:
 	golangci-lint run --config .golangci.yml

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -49,7 +50,7 @@ func TestAuthMechanism_IsValid(t *testing.T) {
 		},
 		{
 			name: "success_X.509",
-			am:   "X.509",
+			am:   "MONGODB-X509",
 			want: true,
 		},
 		{
@@ -91,16 +92,39 @@ func TestParse(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "success_only_required_fields",
+			name: "success_only_required_and_default_fields",
 			args: args{
 				raw: map[string]string{
-					KeyURI:        "mongodb://localhost:27017",
 					KeyDB:         "test",
 					KeyCollection: "users",
 				},
 			},
 			want: Config{
-				URI:        "mongodb://localhost:27017",
+				URI: &url.URL{
+					Scheme: "mongodb",
+					Host:   "localhost:27017",
+				},
+				DB:         "test",
+				Collection: "users",
+			},
+			wantErr: false,
+		},
+		{
+			name: "success_custom_uri",
+			args: args{
+				raw: map[string]string{
+					KeyURI:        "mongodb://localhost:28088/?directConnection=true",
+					KeyDB:         "test",
+					KeyCollection: "users",
+				},
+			},
+			want: Config{
+				URI: &url.URL{
+					Scheme:   "mongodb",
+					Host:     "localhost:28088",
+					Path:     "/",
+					RawQuery: "directConnection=true",
+				},
 				DB:         "test",
 				Collection: "users",
 			},
@@ -117,7 +141,10 @@ func TestParse(t *testing.T) {
 				},
 			},
 			want: Config{
-				URI:        "mongodb://localhost:27017",
+				URI: &url.URL{
+					Scheme: "mongodb",
+					Host:   "localhost:27017",
+				},
 				DB:         "test",
 				Collection: "users",
 				Auth: AuthConfig{
@@ -137,7 +164,10 @@ func TestParse(t *testing.T) {
 				},
 			},
 			want: Config{
-				URI:        "mongodb://localhost:27017",
+				URI: &url.URL{
+					Scheme: "mongodb",
+					Host:   "localhost:27017",
+				},
 				DB:         "test",
 				Collection: "users",
 				Auth: AuthConfig{
@@ -159,7 +189,10 @@ func TestParse(t *testing.T) {
 				},
 			},
 			want: Config{
-				URI:        "mongodb://localhost:27017",
+				URI: &url.URL{
+					Scheme: "mongodb",
+					Host:   "localhost:27017",
+				},
 				DB:         "test",
 				Collection: "users",
 				Auth: AuthConfig{

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -15,6 +15,7 @@
 package source
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -39,7 +40,10 @@ func TestParseConfig(t *testing.T) {
 			},
 			want: Config{
 				Config: config.Config{
-					URI:        "mongodb://localhost:27017",
+					URI: &url.URL{
+						Scheme: "mongodb",
+						Host:   "localhost:27017",
+					},
 					DB:         "test",
 					Collection: "users",
 				},
@@ -58,7 +62,10 @@ func TestParseConfig(t *testing.T) {
 			},
 			want: Config{
 				Config: config.Config{
-					URI:        "mongodb://localhost:27017",
+					URI: &url.URL{
+						Scheme: "mongodb",
+						Host:   "localhost:27017",
+					},
 					DB:         "test",
 					Collection: "users",
 				},
@@ -77,7 +84,10 @@ func TestParseConfig(t *testing.T) {
 			},
 			want: Config{
 				Config: config.Config{
-					URI:        "mongodb://localhost:27017",
+					URI: &url.URL{
+						Scheme: "mongodb",
+						Host:   "localhost:27017",
+					},
 					DB:         "test",
 					Collection: "users",
 				},
@@ -89,8 +99,7 @@ func TestParseConfig(t *testing.T) {
 		{
 			name: "fail_invalid_common_config_missing_required",
 			raw: map[string]string{
-				config.KeyDB:         "test",
-				config.KeyCollection: "users",
+				config.KeyDB: "test",
 			},
 			want:    Config{},
 			wantErr: true,

--- a/source/source.go
+++ b/source/source.go
@@ -64,8 +64,8 @@ func NewSource() sdk.Source {
 func (s *Source) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		config.KeyURI: {
-			Default:  "",
-			Required: true,
+			Default:  "mongodb://localhost:27017",
+			Required: false,
 			Description: "The connection string. " +
 				"The URI can contain host names, IPv4/IPv6 literals, or an SRV record.",
 		},
@@ -139,7 +139,7 @@ func (s *Source) Configure(ctx context.Context, raw map[string]string) error {
 
 // Open opens needed connections and prepares to start producing records.
 func (s *Source) Open(ctx context.Context, sdkPosition sdk.Position) error {
-	opts := options.Client().ApplyURI(s.config.URI).SetRegistry(registry)
+	opts := options.Client().ApplyURI(s.config.URI.String()).SetRegistry(registry)
 
 	var err error
 	s.client, err = mongo.Connect(ctx, opts)

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -17,6 +17,7 @@ package source
 import (
 	"context"
 	"errors"
+	"net/url"
 	"testing"
 	"time"
 
@@ -42,7 +43,10 @@ func TestSource_Configure_success(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(s.config, Config{
 		Config: config.Config{
-			URI:        "mongodb://localhost:27017",
+			URI: &url.URL{
+				Scheme: "mongodb",
+				Host:   "localhost:27017",
+			},
 			DB:         "test",
 			Collection: "users",
 		},
@@ -63,7 +67,7 @@ func TestSource_Configure_failure(t *testing.T) {
 		config.KeyDB:         "test",
 		config.KeyCollection: "users",
 	})
-	is.Equal(err.Error(), `parse source config: parse common config: validate struct: "uri" value must be a valid URI`)
+	is.True(err != nil)
 }
 
 func TestSource_Read_success(t *testing.T) {


### PR DESCRIPTION
### Description

This PR seeks to change the `Config.URI` type from `string` to `*url.URL`. Also, the `Config.URI` field is no longer required and has a default value of `mongodb://localhost:27017`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
