### PR TITLE
Provide client options and a custom BSON codec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,3 +122,6 @@ issues:
         - goerr113
         - maintidx
         - paralleltest # we don't want to run the integration tests in parallel because we want deterministic results
+    - path: codec 
+      linters:
+        - wrapcheck # the codec package contains mongo driver specific code and we don't need to wrap errors from there

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -1,0 +1,53 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codec
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// StringObjectIDCodec is the Codec used for string values.
+// It tries to convert strings into [bson.ObjectID].
+type StringObjectIDCodec struct{}
+
+// EncodeValue implements the [bsoncodec.ValueEncoder] interface.
+// The method tries to convert a string value into [bson.ObjectID].
+//
+//   - If a string can be converted into [bson.ObjectID] it returns it as a [bson.ObjectID].
+//   - If a string cannot be converted into [bson.ObjectID] it returns it as a string, without any transformations.
+func (sc StringObjectIDCodec) EncodeValue(
+	ectx bsoncodec.EncodeContext,
+	vw bsonrw.ValueWriter,
+	val reflect.Value,
+) error {
+	if val.Kind() != reflect.String {
+		return bsoncodec.ValueEncoderError{
+			Name:     "StringEncodeValue",
+			Kinds:    []reflect.Kind{reflect.String},
+			Received: val,
+		}
+	}
+
+	objectID, err := primitive.ObjectIDFromHex(val.String())
+	if err != nil {
+		return vw.WriteString(val.String())
+	}
+
+	return vw.WriteObjectID(objectID)
+}


### PR DESCRIPTION
### Description

This PR seeks to provide client options and a custom BSON codec to Source.
This is already done for Destination, so this PR just adds the same functionality to the `source` branch.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
