### PR TITLE
Implement polling snapshot functionality

### DIFF
--- a/.golangci.goheader.template
+++ b/.golangci.goheader.template
@@ -1,4 +1,4 @@
-Copyright © {{ YEAR }} Meroxa, Inc. & Yalantis
+Copyright © {{ copyright-year }} Meroxa, Inc. & Yalantis
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@ linters-settings:
     ignore-tests: true
   goheader:
     template-path: '.golangci.goheader.template'
+    values:
+      regexp:
+        copyright-year: 20[2-9]\d
   lll:
     line-length: 120
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The connector implements CDC features for MongoDB by using a Change Stream that 
 
 The connector stores a `resumeToken` of every Change Stream event in a position, so the CDC process is resumble.
 
+> **Warning**
+>
+> [Azure CosmosDB for MongoDB](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/change-streams) has very limited support for Change Streams, so they cannot be used for CDC. 
+> If CDC is not possible, like in the case with CosmosDB, the connector supports only insert operations by polling for new documents.
+
 ### Configuration
 
 | name                          | description                                                                                                                         | required | default                                                                                                                                                    |

--- a/source/iterator/errors.go
+++ b/source/iterator/errors.go
@@ -34,4 +34,9 @@ var (
 
 	// errNoDocuments occurs when there're no documents in a collection.
 	errNoDocuments = errors.New("no documents")
+
+	// matchProjectStageErrMessage contains an error text that Azure CosmosDB for MongoDB returns
+	// when you try to create a Change Stream.
+	// We use it to determine whether we should do snapshot polling instead of CDC.
+	matchProjectStageErrMessage = "Change stream must be followed by a match and then a project stage."
 )


### PR DESCRIPTION
### Description

This patch seeks to implement polling snapshot functionality. It's used when the full CDC is not available.
For instance, Azure CosmosDB for MongoDB has very limited support for Change Streams, so they cannot be used within the connector.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
