### PR TITLE
Update go releaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,12 +11,13 @@ builds:
 checksum:
   name_template: checksums.txt
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
### Description

Updates the `.goreleaser.yml` to match that of other connector projects. The previous config would produce the following error message:
```
 ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 14: field replacements not found in type config.Archive
```

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
