### PR TITLE
Support reading documents with timestamps

### DIFF
--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -51,12 +51,12 @@ type position struct {
 
 // marshalSDKPosition marshals the underlying [position] into a [sdk.Position] as JSON bytes.
 func (p *position) marshalSDKPosition() (sdk.Position, error) {
-	positionBytes, err := json.Marshal(p)
+	bytes, err := json.Marshal(p)
 	if err != nil {
 		return nil, fmt.Errorf("marshal position: %w", err)
 	}
 
-	return sdk.Position(positionBytes), nil
+	return bytes, nil
 }
 
 // parsePosition converts an [sdk.Position] into a [position].

--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -16,6 +16,7 @@ package iterator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -155,16 +156,25 @@ func (s *snapshot) next(_ context.Context) (sdk.Record, error) {
 	metadata[metadataFieldCollection] = s.collection.Name()
 	metadata.SetCreatedAt(time.Now())
 
+	elementBytes, err := json.Marshal(element)
+	if err != nil {
+		return sdk.Record{}, fmt.Errorf("failed marshalling record into JSON: %w", err)
+	}
+
 	if s.polling {
 		return sdk.Util.Source.NewRecordCreate(
-			sdkPosition, metadata,
-			sdk.StructuredData{idFieldName: element[idFieldName]}, sdk.StructuredData(element),
+			sdkPosition,
+			metadata,
+			sdk.StructuredData{idFieldName: element[idFieldName]},
+			sdk.RawData(elementBytes),
 		), nil
 	}
 
 	return sdk.Util.Source.NewRecordSnapshot(
-		sdkPosition, metadata,
-		sdk.StructuredData{idFieldName: element[idFieldName]}, sdk.StructuredData(element),
+		sdkPosition,
+		metadata,
+		sdk.StructuredData{idFieldName: element[idFieldName]},
+		sdk.RawData(elementBytes),
 	), nil
 }
 

--- a/source/source.go
+++ b/source/source.go
@@ -84,7 +84,7 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 			Description: "The user's password.",
 		},
 		config.KeyAuthDB: {
-			Default:     "admin",
+			Default:     "",
 			Description: "The name of a database that contains the user's authentication data.",
 		},
 		config.KeyAuthMechanism: {

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -138,7 +138,7 @@ func TestSource_Read_successSnapshot(t *testing.T) {
 	record, err := source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationSnapshot)
-	is.Equal(record.Payload.After, testItem)
+	is.Equal(record.Payload.After, sdk.RawData(testItem.Bytes()))
 }
 
 func TestSource_Read_continueSnapshot(t *testing.T) {
@@ -186,7 +186,7 @@ func TestSource_Read_continueSnapshot(t *testing.T) {
 	record, err := source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationSnapshot)
-	is.Equal(record.Payload.After, firstTestItem)
+	is.Equal(record.Payload.After, sdk.RawData(firstTestItem.Bytes()))
 
 	cancel()
 	ctx, cancel = context.WithCancel(context.Background())
@@ -205,7 +205,7 @@ func TestSource_Read_continueSnapshot(t *testing.T) {
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationSnapshot)
-	is.Equal(record.Payload.After, secondTestItem)
+	is.Equal(record.Payload.After, sdk.RawData(secondTestItem.Bytes()))
 }
 
 func TestSource_Read_successCDC(t *testing.T) {
@@ -254,7 +254,7 @@ func TestSource_Read_successCDC(t *testing.T) {
 	record, err := source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationCreate)
-	is.Equal(record.Payload.After, testItem)
+	is.Equal(record.Payload.After, sdk.RawData(testItem.Bytes()))
 
 	// update the test item
 	updatedTestItem, err := updateTestItem(ctx, testCollection, testItem)
@@ -264,7 +264,7 @@ func TestSource_Read_successCDC(t *testing.T) {
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationUpdate)
-	is.Equal(record.Payload.After, updatedTestItem)
+	is.Equal(record.Payload.After, sdk.RawData(updatedTestItem.Bytes()))
 
 	// delete the test item
 	err = deleteTestItem(ctx, testCollection, updatedTestItem)
@@ -318,7 +318,7 @@ func TestSource_Read_successCDCAfterSnapshotPause(t *testing.T) {
 	record, err := source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationSnapshot)
-	is.Equal(record.Payload.After, snapshotItem)
+	is.Equal(record.Payload.After, sdk.RawData(snapshotItem.Bytes()))
 
 	// stop the source
 	cancel()
@@ -344,13 +344,13 @@ func TestSource_Read_successCDCAfterSnapshotPause(t *testing.T) {
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationCreate)
-	is.Equal(record.Payload.After, cdcCreateItem)
+	is.Equal(record.Payload.After, sdk.RawData(cdcCreateItem.Bytes()))
 
 	// compare the record operation and its payload
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationUpdate)
-	is.Equal(record.Payload.After, cdcUpdateItem)
+	is.Equal(record.Payload.After, sdk.RawData(cdcUpdateItem.Bytes()))
 }
 
 func TestSource_Read_continueCDC(t *testing.T) {
@@ -399,7 +399,7 @@ func TestSource_Read_continueCDC(t *testing.T) {
 	record, err := source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationCreate)
-	is.Equal(record.Payload.After, firstTestItem)
+	is.Equal(record.Payload.After, sdk.RawData(firstTestItem.Bytes()))
 
 	// stop the source
 	cancel()
@@ -426,13 +426,13 @@ func TestSource_Read_continueCDC(t *testing.T) {
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationCreate)
-	is.Equal(record.Payload.After, secondTestItem)
+	is.Equal(record.Payload.After, sdk.RawData(secondTestItem.Bytes()))
 
 	// check that the first item has been updated
 	record, err = source.Read(ctx)
 	is.NoErr(err)
 	is.Equal(record.Operation, sdk.OperationUpdate)
-	is.Equal(record.Payload.After, updatedFirstItem)
+	is.Equal(record.Payload.After, sdk.RawData(updatedFirstItem.Bytes()))
 
 	// stop the source one more time
 	cancel()


### PR DESCRIPTION
### Description

Fixes #79. The fix is by making the source connector return raw data records instead of structured records. That shouldn't affect the functionality of the connector as probably all destination connectors treat structured records and raw records with JSON in them the same.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mongo/pulls) for the same update/change.
- [ ] I have written unit tests. -- tested manually
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
